### PR TITLE
Write Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM alpine
+
+RUN apk --no-cache add python3 py3-pip gcc python3-dev musl-dev libffi-dev openssl-dev
+WORKDIR /app
+COPY ["requirements.txt", "LICENSE", "./"]
+RUN pip3 install -r requirements.txt
+COPY ["zerologon_tester.py", "README.md", "./"]
+
+RUN adduser -h /app -D user && chown user:user * && chmod 744 zerologon_tester.py
+USER user
+
+ENTRYPOINT ["./zerologon_tester.py"]


### PR DESCRIPTION
Although you have a `requirements.txt` file, there are a few unexpected C dependencies that need to be installed for PIP to install the Python dependencies successfuly. This Dockerfile will hopefully help everyone run your test script and patch away!