### PR TITLE
fix(zerologon_tester.py): use is when checking for None

### DIFF
--- a/zerologon_tester.py
+++ b/zerologon_tester.py
@@ -61,7 +61,7 @@ def perform_attack(dc_handle, dc_ip, target_computer):
   for attempt in range(0, MAX_ATTEMPTS):  
     rpc_con = try_zero_authenticate(dc_handle, dc_ip, target_computer)
     
-    if rpc_con is None:
+    if rpc_con:
       print('=', end='', flush=True)
     else:
       break

--- a/zerologon_tester.py
+++ b/zerologon_tester.py
@@ -61,7 +61,7 @@ def perform_attack(dc_handle, dc_ip, target_computer):
   for attempt in range(0, MAX_ATTEMPTS):  
     rpc_con = try_zero_authenticate(dc_handle, dc_ip, target_computer)
     
-    if rpc_con == None:
+    if rpc_con is None:
       print('=', end='', flush=True)
     else:
       break


### PR DESCRIPTION
In Python one should generally check for `None` with `is` instead of `==`.